### PR TITLE
Strip struct before encoding as JSON.

### DIFF
--- a/lib/twirp/encoder.ex
+++ b/lib/twirp/encoder.ex
@@ -62,10 +62,19 @@ defmodule Twirp.Encoder do
 
   def encode(payload, _output, @json <> _) do
     payload
+    |> strip_structs()
     |> Jason.encode!
   end
 
   def encode(payload, output, @proto <> _) do
     output.encode(payload)
   end
+
+  defp strip_structs(map) when is_map(map) do
+    map
+    |> Map.drop([:__struct__])
+    |> Enum.into(%{}, fn {k,v} -> {k, strip_structs(v)} end)
+  end
+
+  defp strip_structs(any), do: any
 end

--- a/test/support/test_service.ex
+++ b/test/support/test_service.ex
@@ -11,6 +11,26 @@ defmodule Twirp.TestService do
     field :msg, 1, type: :string
   end
 
+  defmodule ReqNoJsonProtocol do
+    @moduledoc false
+    use Protobuf, syntax: :proto3
+
+    defstruct [:msg, :sub]
+
+    field :msg, 1, type: :string
+    field :sub, 2, type: ReqSub
+  end
+
+  defmodule ReqSub do
+    @moduledoc false
+
+    use Protobuf, syntax: :proto3
+
+    defstruct [:msg]
+
+    field :msg, 1, type: :string
+  end
+
   defmodule Resp do
     @moduledoc false
     use Protobuf, syntax: :proto3

--- a/test/twirp/encoder_test.exs
+++ b/test/twirp/encoder_test.exs
@@ -3,10 +3,19 @@ defmodule Twirp.EncoderTest do
 
   alias Twirp.Encoder
   alias Twirp.TestService.Req
+  alias Twirp.TestService.ReqNoJsonProtocol
+  alias Twirp.TestService.ReqSub
 
   describe "decode/3 with json" do
     test "converts json to protobuf" do
       assert {:ok, %Req{msg: "test"}} = Encoder.decode(%{msg: "test"}, Req, "application/json")
+    end
+  end
+
+  describe "encode/3 as json " do
+    test "encodes to JSON without implementing a JSON protocol" do
+      assert ~S({"msg":"test","sub":{"msg":"test"}}) ==
+        Encoder.encode(%ReqNoJsonProtocol{msg: "test", sub: %ReqSub{msg: "test"}}, ReqNoJsonProtocol, "application/json")
     end
   end
 end


### PR DESCRIPTION
The protobuf struct generator doesn't include `@derive` module
attributes to setup a JSON encoder. This casuses errors when trying to
encode the structs. Since, by the point of encoding we have already
verified that the returned data is the expected struct we can trim off
the struct field and encode the data as a map.